### PR TITLE
Fixed "list index out of range" on resolution change

### DIFF
--- a/minecraft_dynmap_timemachine/time_machine.py
+++ b/minecraft_dynmap_timemachine/time_machine.py
@@ -52,13 +52,12 @@ class TimeMachine(object):
 
         return dest_img
 
-
     def compare_images(self, image1, image2):
         file1data = list(image1.getdata())
         file2data = list(image2.getdata())
 
         diff = 0
-        for i in range(len(file1data)):
+        for i in range(min(len(file1data), len(file2data))):
             if file1data[i] != file2data[i]:
                 diff += 1
 


### PR DESCRIPTION
When using the timelapse functionality and changing the tile resolution in-between screenshots (downsizing), it created an "IndexError: list index out of range".
This was due to the different image array lengths.